### PR TITLE
Fix #5, filter object ids using get_object() function

### DIFF
--- a/ngdf/dataset.py
+++ b/ngdf/dataset.py
@@ -240,7 +240,7 @@ class GraspDataModule(pl.LightningDataModule):
         objects = self.get_objects(dset_grasp)
         test_ids = self.collect_grasps(dset_grasp, objects, test=True)
         test_ids = test_ids[: self.cfg.net.max_test_samples]
-        pc_dset = PointCloudDataset(self.cfg)
+        pc_dset = PointCloudDataset(self.cfg, objects)
         _, val_pc_dict = pc_dset.get_dicts()
         self.grasps_test = GraspDataset(
             self.cfg, dset_grasp, objects, test_ids, val_pc_dict

--- a/scripts/eval/grasp_level_set/multobj.sh
+++ b/scripts/eval/grasp_level_set/multobj.sh
@@ -21,4 +21,4 @@ python ngdf/evaluate.py \
     --ckpt_path=data/models/Bottle_intracategory_partial/default_default_train-graspfields/0_0_248dyj7f/checkpoints/epoch=0-step=199999.ckpt \
     --data_path=data/acronym_multobj/grasp-dataset \
     --pc_data_path=data/acronym_multobj/shape-dataset \
-    --eval_objs=Bottle_244894af3ba967ccd957eaf7f4edb205_0.012953570261294404
+    --eval_objs=Bottle

--- a/scripts/eval/grasp_level_set/perobj.sh
+++ b/scripts/eval/grasp_level_set/perobj.sh
@@ -21,7 +21,7 @@ python ngdf/evaluate.py \
     --ckpt_path=data/models/objBottle-archdeepsdf_partial100/default_default_train-graspfields/5_5_3tbhr0ee/checkpoints/epoch=11-step=510732.ckpt \
     --data_path=data/acronym_perobj/grasp-dataset \
     --pc_data_path=data/acronym_perobj/shape-dataset \
-    --eval_objs=Bottle_244894af3ba967ccd957eaf7f4edb205_0.012953570261294404
+    --eval_objs=Bottle
 
 echo "Evaluating Bowl..."
 python ngdf/evaluate.py \
@@ -32,7 +32,7 @@ python ngdf/evaluate.py \
     --ckpt_path=data/models/objBowl-archdeepsdf_partial100/default_default_train-graspfields/7_7_3n5713s0/checkpoints/epoch=12-step=550822.ckpt \
     --data_path=data/acronym_perobj/grasp-dataset \
     --pc_data_path=data/acronym_perobj/shape-dataset \
-    --eval_objs=Bowl_9a52843cc89cd208362be90aaa182ec6_0.0008104428339208306
+    --eval_objs=Bowl
 
 echo "Evaluating Mug..."
 python ngdf/evaluate.py \
@@ -43,4 +43,4 @@ python ngdf/evaluate.py \
     --ckpt_path=data/models/objMug-archdeepsdf_partial100/default_default_train-graspfields/2_2_1rvf96ap/checkpoints/epoch=5-step=253729.ckpt \
     --data_path=data/acronym_perobj/grasp-dataset \
     --pc_data_path=data/acronym_perobj/shape-dataset \
-    --eval_objs=Mug_40f9a6cc6b2c3b3a78060a3a3a55e18f_0.0006670441940038386
+    --eval_objs=Mug


### PR DESCRIPTION
This PR addresses a bug brought up in Issue #5: Object ids that are in the `grasp-dataset/dataset.hdf5` file but not in the `grasps/` were causing the dataloader to break. 

There can be ids that aren't in `grasps/` if some of the objects in `grasps/` are removed to create a test set, as is the case for the `acronym_multobj` dataset. 

This PR introduces a function `get_objects()` in the `GraspDataModule` class to filter out object ids not in `grasps/`.  

The fix was tested by running the scripts for single and multi-object Bottle model training, and the grasp level set evaluation script.  