### PR TITLE
Fix #8 by adding experiment parameter to scripts

### DIFF
--- a/scripts/train/multobj_Bottle.sh
+++ b/scripts/train/multobj_Bottle.sh
@@ -10,6 +10,7 @@ PROJECT_ROOT=$SCRIPT_DIR/../..
 DATA_ROOT=$SCRIPT_DIR/../../data
 
 python ngdf/train.py \
+    experiment=multobj_Bottle \
     experiment_yml=$SCRIPT_DIR/../../ngdf/config/experiments/multobj_Bottle.yaml \
     data_root=$DATA_ROOT \
     project_root=$PROJECT_ROOT

--- a/scripts/train/perobj_Bottle.sh
+++ b/scripts/train/perobj_Bottle.sh
@@ -10,6 +10,7 @@ PROJECT_ROOT=$SCRIPT_DIR/../..
 DATA_ROOT=$SCRIPT_DIR/../../data
 
 python ngdf/train.py \
+    experiment=perobj_Bottle \
     experiment_yml=$SCRIPT_DIR/../../ngdf/config/experiments/perobj_Bottle.yaml \
     data_root=$DATA_ROOT \
     project_root=$PROJECT_ROOT 

--- a/scripts/train/perobj_Bowl.sh
+++ b/scripts/train/perobj_Bowl.sh
@@ -10,6 +10,7 @@ PROJECT_ROOT=$SCRIPT_DIR/../..
 DATA_ROOT=$SCRIPT_DIR/../../data
 
 python ngdf/train.py \
+    experiment=perobj_Bowl \
     experiment_yml=$SCRIPT_DIR/../../ngdf/config/experiments/perobj_Bowl.yaml \
     data_root=$DATA_ROOT \
     project_root=$PROJECT_ROOT

--- a/scripts/train/perobj_Mug.sh
+++ b/scripts/train/perobj_Mug.sh
@@ -10,6 +10,7 @@ PROJECT_ROOT=$SCRIPT_DIR/../..
 DATA_ROOT=$SCRIPT_DIR/../../data
 
 python ngdf/train.py \
+    experiment=perobj_Mug \
     experiment_yml=$SCRIPT_DIR/../../ngdf/config/experiments/perobj_Mug.yaml \
     data_root=$DATA_ROOT \
     project_root=$PROJECT_ROOT


### PR DESCRIPTION
## Summary of the issue
This PR provides a workaround for Issue #8, where the run directory of an experiment is always set to the `dbg` folder. This bug occurs because hydra changes the working directory of the run before the experiment name is overridden in train.py.


## How this PR fixes the issue
This PR fixes the issue by overriding the experiment name in the training scripts as well as in the yaml files. By overriding the experiment name in the training script, the experiment name is updated before hydra changes the working directory.

## How the PR was tested
The fix was tested locally and successfully changed the run directory for the experiment according to the experiment name. 

## Other comments
This fix creates some redundancy as the experiment name is specified both in the training script and in the yaml file. A better fix would be to reorganize the hydra config to make use of the `defaults` feature described [here](https://hydra.cc/docs/0.11/tutorial/defaults).