### PR TITLE
Fix #12, script should evaluate on held-out Bottle instance

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.linting.enabled": false
-}

--- a/scripts/eval/grasp_level_set/multobj.sh
+++ b/scripts/eval/grasp_level_set/multobj.sh
@@ -12,6 +12,7 @@ do
     esac
 done
 
+# Evaluate on held-out test Bottle
 echo "Evaluating Bottle..."
 python ngdf/evaluate.py \
     $pb_arg \
@@ -19,6 +20,6 @@ python ngdf/evaluate.py \
     --max_iter=3000 \
     --save_images \
     --ckpt_path=data/models/Bottle_intracategory_partial/default_default_train-graspfields/0_0_248dyj7f/checkpoints/epoch=0-step=199999.ckpt \
-    --data_path=data/acronym_multobj/grasp-dataset \
-    --pc_data_path=data/acronym_multobj/shape-dataset \
+    --data_path=data/acronym_perobj/grasp-dataset \
+    --pc_data_path=data/acronym_perobj/shape-dataset \
     --eval_objs=Bottle


### PR DESCRIPTION
This PR fixes #12 by updating the `data_path` and `pc_data_path` in `scripts/eval/grasp_level_set/multobj.sh`. It also removes an unnecessary `.vscode` folder. 

The fix was tested manually.