### PR TITLE
Add install scripts and docker instructions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,11 @@ repos:
         stages: [commit]
         language: system
         entry: jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace
+    -   id: black
+        name: black
+        files: \.py$
+        stages: [commit]
+        exclude: ^(acronym|contact_graspnet|differentiable-robot-model|ndf_robot|OMG-Planner|scripts|theseus)
+        language: python
+        language_version: python3.7
+        entry: black

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:20.04
+
+RUN apt update
+RUN apt install -y libsuitesparse-dev
+
+RUN mkdir -p /workspace/NGDF
+WORKDIR /workspace/NGDF

--- a/README.md
+++ b/README.md
@@ -23,41 +23,18 @@
 ## Setup
 
 1. Clone the repository: `git clone --recursive git@github.com:facebookresearch/NGDF.git`
-2. Create a conda environment and install package dependencies
+2. Create a conda environment and install package dependencies. Note: [mamba](https://mamba-framework.readthedocs.io/en/latest/) is highly recommended as a drop-in replacement for conda.
 
     ```
     cd NGDF
-    conda env create -f ngdf_env.yml
-    conda activate ngdf
-    pip install -e .
+    bash install.sh
     ```
     Install [PyTorch](https://pytorch.org/get-started/locally/) separately, based on your CUDA driver version. The command below was tested on a 3080/3090 with CUDA 11.1:
     ```
+    source prepare.sh
     pip install torch==1.8.1+cu111 torchvision==0.9.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html
     ```
-3. Setup submodules
-
-    * ndf_robot
-        ```
-        cd ndf_robot && pip install -e .
-        ```
-        Source ndf_robot whenever the conda env is activated
-        ```
-        conda activate ngdf
-        cd $CONDA_PREFIX
-        mkdir -p ./etc/conda/activate.d
-        touch ./etc/conda/activate.d/ndf_env.sh
-        echo "cd /PATH/TO/ndf_robot && source ndf_env.sh && cd -" >> ./etc/conda/activate.d/ndf_env.sh
-        ```
-        Download pre-trained `ndf_robot` weights: 
-        ```
-        cd NGDF/ndf_robot
-        bash ndf_robot/scripts/download_demo_weights.sh
-        ```
-    * acronym
-        ```
-        cd acronym && pip install -e .
-        ```
+    Run `source prepare.sh` before running any `ngdf` training or evaluation code to activate the environment and set env variables. 
 
 ## Folder structure
 ```bash
@@ -77,7 +54,7 @@ NGDF
 
 1. Download datasets `acronym_perobj` and `acronym_multobj` from [this Google Drive link](https://drive.google.com/drive/folders/1h88_hjP5v6cGyEOpK-g2J24FMeXKn99P?usp=share_link). Place the datasets in `data/`.
 
-    The datasets are required to compute the closest grasp metric. 
+    The datasets are required to compute the closest grasp metric and are also used in training. 
 
 2. Run evaluation
     * Download pre-trained models and configs into `data/models` from this [link](https://drive.google.com/drive/folders/1d4DjHp-YYIZMtESbLb9zYZavxQ14ny-2?usp=sharing)
@@ -108,12 +85,6 @@ NGDF
         git remote add parent https://github.com/facebookresearch/differentiable-robot-model.git
         git fetch parent
         python setup.py develop
-        ```
-
-    * theseus-ai
-        ```
-        cd theseus
-        pip install -e .
         ```
 
     * Contact-GraspNet
@@ -147,14 +118,25 @@ NGDF
     bash scripts/train/multobj_Bottle.sh
     ```
 
+### Docker instructions
+* Building docker
+    ```
+    cd NGDF
+    docker build -t ngdf . 
+    ```
+* Run docker
+    * `bash docker_run.sh`
+    * `source prepare.sh`
+    * Run the same commands for training in the container under `root:/workspace/NGDF#`
+
 ## Bibtex
 
 ```
 @article{weng2022ngdf,
   title={Neural Grasp Distance Fields for Robot Manipulation,
   author={Weng, Thomas and Held, David and Meier, Franziska and Mukadam, Mustafa},
-  journal={arXiv preprint arXiv:2211.02647},
-  year={2022}
+  journal={IEEE International Conference on Robotics and Automation (ICRA)},
+  year={2023}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ NGDF
 
 ```
 @article{weng2022ngdf,
-  title={Neural Grasp Distance Fields for Robot Manipulation,
+  title={Neural Grasp Distance Fields for Robot Manipulation},
   author={Weng, Thomas and Held, David and Meier, Franziska and Mukadam, Mustafa},
   journal={IEEE International Conference on Robotics and Automation (ICRA)},
   year={2023}

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# get directory of current file
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR_NAME=${PWD##*/} # name of file dir
+CONDA_ROOT=$(conda info --base)
+
+# run docker container
+# Mount code directory into both /workspace 
+# and original path on host so pip -e installs don't break
+docker run \
+    -v $CONDA_ROOT:$CONDA_ROOT \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -v $DIR:/workspace/$DIR_NAME  \
+    -v $DIR:$DIR \
+    --gpus all \
+    -e DISPLAY=$DISPLAY \
+    -e QT_X11_NO_MITSHM=1 \
+    -e PATH=$CONDA_ROOT/bin:$PATH \
+    -it ngdf:latest bash

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Pipe all output to log file
+exec > >(tee -i /tmp/ngdf_install.log)
+
+# Get directory of current file
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Install or update ngdf env
+set -e # exit on error
+if [ -d "$CONDA_PREFIX/envs/ngdf" ]; then
+    conda env update -f ngdf_env.yml
+else
+    conda env create -f ngdf_env.yml
+fi
+
+# # Set up ndf_robot hook
+# source activate ngdf
+# cd $CONDA_PREFIX
+# if [ ! -d "./etc/conda/activate.d" ]; then
+#     mkdir -p ./etc/conda/activate.d
+#     touch ./etc/conda/activate.d/ndf_env.sh
+#     echo "cd $DIR/ndf_robot && source ndf_env.sh && cd -" >> ./etc/conda/activate.d/ndf_env.sh
+# fi
+
+# Download ndf_robot pretrained weights
+if [ ! -f "$DIR/ndf_robot/src/model_weights/multi_category_weights.pth" ]; then
+    cd $DIR/ndf_robot
+    source ndf_env.sh
+    bash $DIR/ndf_robot/scripts/download_demo_weights.sh
+fi

--- a/ngdf/train.py
+++ b/ngdf/train.py
@@ -29,7 +29,7 @@ def init_model(cfg):
     return model
 
 
-@hydra.main(config_path="config", config_name="train")
+@hydra.main(version_base="1.1", config_path="config", config_name="train")
 def main(cfg):
     if cfg.experiment_yml is not None:
         exp_cfg = OmegaConf.load(cfg.experiment_yml)

--- a/ngdf_env.yml
+++ b/ngdf_env.yml
@@ -10,21 +10,27 @@ dependencies:
   - cudatoolkit-dev=11.1.1
   - cudnn=8.1
   - pip:
-    - h5py==3.1.0
-    - numpy==1.19.2
-    - Pillow==9.2.0
-    - matplotlib==3.3.2
-    - pybullet==3.1.3
-    - hydra-core==1.2.0
-    - gym==0.25.1
-    - pyyaml==6.0
-    - trimesh==3.13.5
-    - pytransform3d==1.14.0
-    - opencv-python==4.6.0.66
-    - pytorch-lightning==1.4.1
-    - jupyter==1.0.0
-    - wandb==0.13.1
-    - pandas==1.3.5
-    - torchmetrics==0.7.0
-    - tabulate
     - black
+    - -e ./
+    - -e ./acronym
+    - -e ./ndf_robot
+    - -e ./theseus
+    - gym==0.25.1
+    - h5py==3.1.0
+    - hydra-core==1.2.0
+    - jupyter==1.0.0
+    - matplotlib==3.3.2
+    - numpy==1.19.2
+    - opencv-python==4.6.0.66
+    - pandas==1.3.5
+    - Pillow==9.2.0
+    - pre-commit==2.21.0
+    - pybullet==3.1.3
+    - pytorch-lightning==1.4.1
+    - pytransform3d==1.14.0
+    - pyyaml==6.0
+    - setuptools==41.6.0
+    - tabulate==0.9.0
+    - torchmetrics==0.7.0
+    - trimesh==3.13.5
+    - wandb==0.16.0

--- a/ngdf_env.yml
+++ b/ngdf_env.yml
@@ -33,4 +33,4 @@ dependencies:
     - tabulate==0.9.0
     - torchmetrics==0.7.0
     - trimesh==3.13.5
-    - wandb==0.16.0
+    - wandb==0.13.1

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Get current directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Source ngdf conda env
+source activate ngdf
+
+# Source ndf_robot
+cd $DIR/ndf_robot && source ndf_env.sh
+cd -
+


### PR DESCRIPTION
1. Added scripts to streamline the installation process. `install.sh` runs the majority of the installation. `acronym`, `ndf_robot`, and `theseus` are now automatically installed as editable packages with `ngdf_env.yml`. `prepare.sh` is now used to activate the conda env. The installation instructions in the README have been updated to incorporate the new scripts. 

2. Added scripts for training in Docker. `docker_build.sh` and `docker_run.sh` are used to build and run the docker container. The README has been updated with instructions on how to run these scripts. 

3. Added black to pre-commit, updated version base parameter, updated citation from arxiv to ICRA.